### PR TITLE
Fix issue in SearchBar when server responds with 500 internal server error

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -14,7 +14,7 @@ const SearchBar = ({updateResults}) => {
 
       const getImages = results.map(async (plant) => {
         await getPlantDetails(plant.id).then(details => {
-          plant.imageURL = details.images.length > 0 ? details.images[0].url : null;
+          plant.imageURL = (details && details.images.length > 0) ? details.images[0].url : null;
         })
       });
 


### PR DESCRIPTION
Adds a null check on the results of getPlantDetails in SearchBar. Closes #46 