### PR TITLE
Disable searching for empty string

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -9,7 +9,9 @@ const SearchBar = ({updateResults}) => {
 
   function handleSubmit(event) {
     event.preventDefault();
-    history.push("/SearchResults/" + searchInput.value + "/" + completeDataInput.checked);
+    if (searchInput.value.length > 0) {
+      history.push("/SearchResults/" + searchInput.value + "/" + completeDataInput.checked);
+    }
   }
 
   return (


### PR DESCRIPTION
Adds a check on the length of searchInput in search bar. Closes #68 